### PR TITLE
Fix diff error on binary files

### DIFF
--- a/lib/models/diffs/diff.coffee
+++ b/lib/models/diffs/diff.coffee
@@ -15,7 +15,7 @@ class Diff extends List
 
   removeHeader: (diff) ->
     # Remove first two lines, which name the file
-    @header = diff.match(/^(.*?\n){2}/)[0]
+    @header = diff.match(/^(.*?\n){2}/)?[0]
     diff.replace /^(.*?\n){2}/, ""
 
   splitChunks: (diff) ->


### PR DESCRIPTION
Fix diff error on binary files when opening Atomatigit and "toggle diff" on these files.

![err-diff-binary](https://cloud.githubusercontent.com/assets/5219415/3075016/f31c974a-e35e-11e3-90d6-16680f1b4f31.png)
