### PR TITLE
Remove pathwatcher dependency

### DIFF
--- a/lib/models/diffs/diff-chunk.coffee
+++ b/lib/models/diffs/diff-chunk.coffee
@@ -1,11 +1,11 @@
+_    = require 'underscore'
+fs   = require 'fs'
 path = require 'path'
 
+{git}    = require '../../git'
 DiffLine = require './diff-line'
 ListItem = require '../list-item'
-{git} = require '../../git'
-{File} = require 'pathwatcher'
 
-_ = require 'underscore'
 
 ##
 # A DiffChunk represents one consecutive block of altered lines. The end-goal of
@@ -36,15 +36,15 @@ class DiffChunk extends ListItem
     @get("header") + @get("chunk") + "\n"
 
   kill: ->
-    (new File @patchPath()).write(@patch())
+    fs.writeFileSync(@patchPath(), @patch())
     git.git "apply --reverse #{@patchPath()}"
 
   stage: ->
-    (new File @patchPath()).write(@patch())
+    fs.writeFileSync(@patchPath(), @patch())
     git.git "apply --cached #{@patchPath()}"
 
   unstage: ->
-    (new File @patchPath()).write(@patch())
+    fs.writeFileSync(@patchPath(), @patch())
     git.git "apply --cached --reverse #{@patchPath()}"
 
   patchPath: ->

--- a/lib/models/repo.coffee
+++ b/lib/models/repo.coffee
@@ -1,6 +1,7 @@
 _ = require 'underscore'
+fs = require 'fs'
+path = require 'path'
 {Model} = require 'backbone'
-{File} = require 'pathwatcher'
 
 {git} = require '../git'
 {FileList} = require './files'
@@ -31,7 +32,10 @@ class Repo extends Model
     @active_list.leaf()
 
   commitMessagePath: ->
-    atom.project.getRepo().getWorkingDirectory() + "/.git/COMMIT_EDITMSG_ATOMATIGIT"
+    path.join(
+      atom.project.getRepo()?.getWorkingDirectory(),
+      '/.git/COMMIT_EDITMSG_ATOMATIGIT'
+    )
 
   headRefsCount: ->
     atom.project.getRepo().getReferences().heads.length
@@ -55,8 +59,7 @@ class Repo extends Model
     if atom.config.get("atomatigit.pre_commit_hook") != ""
       atom.workspaceView.trigger(atom.config.get("atomatigit.pre_commit_hook"))
 
-    file = new File @commitMessagePath()
-    file.write('')
+    fs.writeFileSync(@commitMessagePath(), '')
 
     editor = atom.workspace.open(@commitMessagePath(), {changeFocus: true})
     editor.then (result) =>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "backbone": "1.x",
     "underscore": "1.x",
     "jquery": "1.x",
-    "pathwatcher": "1.x",
     "fs-plus": "~2.2.3"
   }
 }


### PR DESCRIPTION
@diiq I removed `pathwatcher` completely since we do not need a native module to write to a file.

Closes #29.
