### PR TITLE
RepoView refreshes after branch creation.

### DIFF
--- a/lib/models/repo.coffee
+++ b/lib/models/repo.coffee
@@ -130,6 +130,7 @@ class Repo extends Model
       callback: (name) ->
         git.cmd "checkout -b #{name}"
         .catch (error) -> new ErrorView(error)
+        .done -> atom.workspaceView.trigger 'atomatigit:refresh'
 
   # Public: Initiate a user defined git command.
   initiateGitCommand: =>


### PR DESCRIPTION
It's confusing to create a branch and not have it show up in the list of available branches. Refreshing the view fixes that problem.