### PR TITLE
Added focus indication and made focus more stable

### DIFF
--- a/lib/models/commits/commit-list.coffee
+++ b/lib/models/commits/commit-list.coffee
@@ -15,8 +15,8 @@ class CommitList extends List
     git.log(@branch?.head() ? 'HEAD')
     .then (commits) =>
       @reset _.map(commits, (commit) -> new Commit(commit))
-      @select @selectedIndex
       @trigger('repaint') unless options.silent
+      @select @selectedIndex
     .catch (error) -> new ErrorView(error)
 
 module.exports = CommitList

--- a/lib/models/repo.coffee
+++ b/lib/models/repo.coffee
@@ -123,6 +123,7 @@ class Repo extends Model
   completeCommit: =>
     git.commit @commitMessagePath()
     .then @reload
+    .then -> atom.workspaceView.trigger 'atomatigit:focus'
     .catch (error) -> new ErrorView(error)
     .finally @cleanupCommitMessageFile
 

--- a/lib/views/input-view.coffee
+++ b/lib/views/input-view.coffee
@@ -12,9 +12,8 @@ class InputView extends View
     @currentPane = atom.workspace.getActivePane()
     atom.workspaceView.append(this)
     @inputEditor.focus()
-    @on 'core:cancel', @detach
-    @inputEditor.on 'core:confirm', =>
-      @detach()
-      callback?(@inputEditor.getText())
+    @on 'focusout', @detach
+    @on 'core:cancel', -> atom.workspaceView.trigger 'atomatigit:focus'
+    @inputEditor.on 'core:confirm', => callback?(@inputEditor.getText())
 
 module.exports = InputView

--- a/stylesheets/atomatigit.less
+++ b/stylesheets/atomatigit.less
@@ -155,6 +155,7 @@
     .name {
       display: block;
       font-size: 2em;
+      font-weight: bold;
     }
     .commit {
       display: block;
@@ -176,7 +177,6 @@
     border-left: solid 1px @background-color-selected;
     .current-branch-view .name {
       color: @background-color-selected;
-      font-weight: bold;
     }
   }
   .tab-bar {

--- a/stylesheets/atomatigit.less
+++ b/stylesheets/atomatigit.less
@@ -179,6 +179,12 @@
         color: @text-color;
       }
     }
+
+    border-left: solid 1px @background-color-selected;
+    .current-branch-view .name {
+      color: @background-color-selected;
+      font-weight: bold;
+    }
   }
   .tab-bar {
     display: -webkit-flex;

--- a/stylesheets/atomatigit.less
+++ b/stylesheets/atomatigit.less
@@ -84,10 +84,6 @@
       padding-left: 25 * @units;
     }
 
-    &.selected {
-      background-color: @button-background-color;
-    }
-
     .diff {
       font-family: monospace;
 
@@ -126,9 +122,6 @@
   .branch-brief-view {
     padding: 5 * @units;
     padding-left: 25 * @units;
-    &.selected {
-      background-color: @button-background-color;
-    }
 
     .name {
       margin: 0px;
@@ -173,7 +166,7 @@
 
   &.focused {
     background-color: darken(@tree-view-background-color, 2%);
-    .selected .filename, .branch-brief-view.selected, .commit.selected {
+    .selected .filename, .branch-brief-view.selected, .commit.selected, .file.selected {
       background-color: @background-color-selected;
       .message {
         color: @text-color;


### PR DESCRIPTION
When using atomatigit, I was often confused as to when atomatigit had my focus. I wouldn't want to accidentally issue some git commands via hotkey while trying to type something. So I wrote up a quick stylesheet to indicate focus. Once I had that stylesheet added, I could easily see when the RepoView had focus and not. It seemed that `focusout` was causing temporary outages of focus when clicking on the RepoView (mousedown would lose focus, mouseup would bring it back) which wasn't a big deal before but now with the new styles it was clear that the focus was leaving and coming back. It looked pretty bad. So I reworked the logic so that clicking outside of the RepoView will remove focus, and using hotkeys to navigate away will remove the focus. I also exposed the `focus`, `unfocus`, and `toggleFocus` functions. The comments said `focus` and `unfocus` were Public but they were never actually exposed, and I wanted to be able to make some hotkeys for myself so I went ahead and exposed them. =) `toggleFocus` mimics `atom/tree-view`'s `toggleFocus` in that if it ends up unfocusing, it will give focus to the last file you were working with. The final change I made was that I made RepoView get focus after a refresh. There were two cases that prompted me to do this. The first was after doing a custom git command `:` you would hit enter and nothing would have focus. The second was after doing a commit message, you would save the file and nothing would have focus again. It seems more intuitive to me to give the focus back to the RepoView.

    Exposed focus functions.

    Added Public Function:
      toggleFocus - toggles focus of RepoView

    Added Internal Functions:
      hasFocus - checks if RepoView has focus
      unfocusIfNotClicked - removes focus when clicking outside of RepoView
      unfocusIfNotActive - removes focus when typing outside of RepoView

    Reworked focus logic to not use 'focusout' since clicking RepoView
      would cause temporary loss of focus and then refocus.

    RepoView now gets focus after a refresh.
    Added styles to indicate focus.