### PR TITLE
Show on Startup config option added

### DIFF
--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -16,6 +16,12 @@ module.exports =
       type: 'string'
       default: ''
       order: 2
+    show_on_startup:
+      title: 'Show on Startup'
+      description: 'Check this if you want atomatigit to show up when Atom is loaded'
+      type: 'boolean'
+      default: false
+      order: 3
 
   repo: null
   repoView: null

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -1,6 +1,4 @@
-Repo      = require './models/repo'
-RepoView  = require './views/repo-view'
-ErrorView = require './views/error-view'
+Repo = RepoView = ErrorView = null
 
 module.exports =
   config:
@@ -28,7 +26,10 @@ module.exports =
 
   # Public: Package activation.
   activate: (state) ->
+    ErrorView = require './views/error-view'
     return @errorNoGitRepo() unless atom.project.getRepo()
+    Repo      = require './models/repo'
+    RepoView  = require './views/repo-view'
     @insertCommands()
     @show()
 

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -3,9 +3,19 @@ RepoView  = require './views/repo-view'
 ErrorView = require './views/error-view'
 
 module.exports =
-  configDefaults:
-    debug: false
-    pre_commit_hook: ''
+  config:
+    debug:
+      title: 'Debug'
+      description: 'Toggle debugging tools'
+      type: 'boolean'
+      default: false
+      order: 1
+    pre_commit_hook:
+      title: 'Pre Commit Hook'
+      description: 'Command to run for the pre commit hook'
+      type: 'string'
+      default: ''
+      order: 2
 
   repo: null
   repoView: null

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -32,7 +32,7 @@ module.exports =
     Repo      = require './models/repo'
     RepoView  = require './views/repo-view'
     @insertCommands()
-    @show()
+    atom.workspaceView.trigger 'atomatigit:show' if atom.config.get('atomatigit.show_on_startup')
 
   # Public: Close the atomatigit pane.
   hide: ->

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -26,6 +26,7 @@ module.exports =
 
   # Public: Package activation.
   activate: (state) ->
+    @insertShowCommand()
     ErrorView = require './views/error-view'
     return @errorNoGitRepo() unless atom.project.getRepo()
     Repo      = require './models/repo'
@@ -55,7 +56,10 @@ module.exports =
   errorNoGitRepo: ->
     new ErrorView(message: 'Project is no git repository!')
 
+  # Internal: Register show command with atom.
+  insertShowCommand: ->
+    atom.workspaceView.command 'atomatigit:show', => @show()
+
   # Internal: Register package commands with atom.
   insertCommands: ->
-    atom.workspaceView.command 'atomatigit:show', => @show()
     atom.workspaceView.command 'atomatigit:close', => @hide()

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -24,6 +24,8 @@ module.exports =
   repo: null
   repoView: null
 
+  startup_error_shown: false
+
   # Public: Package activation.
   activate: (state) ->
     @insertShowCommand()
@@ -54,7 +56,8 @@ module.exports =
 
   # Internal: Display error message if the project is no git repository.
   errorNoGitRepo: ->
-    new ErrorView(message: 'Project is no git repository!')
+    new ErrorView(message: 'Project is no git repository!') if @startup_error_shown
+    @startup_error_shown = true
 
   # Internal: Register show command with atom.
   insertShowCommand: ->

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "main": "./lib/atomatigit",
   "version": "1.1.0",
   "description": "Full git interaction, a la magit",
-  "activationEvents": [
-    "atomatigit:show"
-  ],
   "repository": "https://github.com/diiq/atomatigit",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
I tried to break my changes out into individual commits so you could have a better idea of what I was doing and why.

+ 6796c00 - We have to load `ErrorView` no matter what. I moved the other two after the initial check so we don't load them unnecessarily.
+ 5bc98c0 - When we open up a non-git repo, we still want users to be able to try to open atomatigit.
+ b258206 - Having the editor trigger show instead of us calling it explicitly makes sure the editor is ready to show atomatigit. When calling it explicitly I was getting 2 panes.
+ 363e6ea - When opening a non-git project, it seemed kinda weird to tell them that it's not a Git Repository. We still want to show it to them if they manually try to open it, so I just put it behind a flag.