### PR TITLE
Commit comparisons / bug fixes / optimizations

### DIFF
--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -52,7 +52,7 @@ module.exports =
       @repoView = new RepoView(@repo)
       @repoView.InitPromise.then => @append()
     else
-      @repo.reload().then => @append()
+      @append()
 
   # Internal: Destroy atomatigit instance.
   deactivate: ->

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -38,15 +38,21 @@ module.exports =
   hide: ->
     @repoView.detach() if @repoView.hasParent()
 
+  # Internal: Append the repoView (if not already) and focus the pane
+  append: ->
+    atom.workspaceView.appendToRight(@repoView) unless @repoView?.hasParent()
+    @repoView.focus()
+
   # Public: Open (or focus) the atomatigit window.
   show: ->
     return @errorNoGitRepo() unless atom.project.getRepo()
     @loadClasses() unless Repo and RepoView
     @repo ?= new Repo()
-    @repoView ?= new RepoView(@repo)
-    @repo.reload().then =>
-      atom.workspaceView.appendToRight(@repoView) unless @repoView?.hasParent()
-      @repoView.focus()
+    if !@repoView?
+      @repoView = new RepoView(@repo)
+      @repoView.InitPromise.then => @append()
+    else
+      @repo.reload().then => @append()
 
   # Internal: Destroy atomatigit instance.
   deactivate: ->

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -34,10 +34,9 @@ module.exports =
 
   # Public: Package activation.
   activate: (state) ->
-    @insertShowCommand()
+    @insertCommands()
     return @errorNoGitRepo() unless atom.project.getRepo()
     @loadClasses()
-    @insertCommands()
     atom.workspaceView.trigger 'atomatigit:show' if atom.config.get('atomatigit.show_on_startup')
 
   # Public: Close the atomatigit pane.
@@ -72,12 +71,9 @@ module.exports =
     new ErrorView(message: 'Project is no git repository!') if @startup_error_shown
     @startup_error_shown = true
 
-  # Internal: Register show command with atom.
-  insertShowCommand: ->
-    atom.workspaceView.command 'atomatigit:show', => @show()
-
   # Internal: Register package commands with atom.
   insertCommands: ->
+    atom.workspaceView.command 'atomatigit:show', => @show()
     atom.workspaceView.command 'atomatigit:close', => @hide()
 
   # Internal: Load required classes on activation

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -20,6 +20,12 @@ module.exports =
       type: 'boolean'
       default: false
       order: 3
+    display_commit_comparisons:
+      title: 'Display Commit Comparisons'
+      description: 'Display how many commits ahead/behind your branches are'
+      type: 'boolean'
+      default: true
+      order: 4
 
   repo: null
   repoView: null

--- a/lib/atomatigit.coffee
+++ b/lib/atomatigit.coffee
@@ -37,6 +37,7 @@ module.exports =
   # Public: Close the atomatigit pane.
   hide: ->
     @repoView.detach() if @repoView.hasParent()
+    atom.workspace.getActivePane().activate()
 
   # Internal: Append the repoView (if not already) and focus the pane
   append: ->

--- a/lib/models/branches/current-branch.coffee
+++ b/lib/models/branches/current-branch.coffee
@@ -16,7 +16,9 @@ class CurrentBranch extends LocalBranch
     git.revParse('HEAD', 'abbrev-ref': true).then (@name) =>
       git.getCommit('HEAD').then (gitCommit) =>
         @commit = new Commit(gitCommit)
-        @trigger('repaint') unless silent
+        if !silent
+          @trigger 'repaint'
+          @compareCommits() if atom.config.get('atomatigit.display_commit_comparisons')
     .catch (error) -> new ErrorView(error)
 
   # Public: Return the HEAD.

--- a/lib/models/repo.coffee
+++ b/lib/models/repo.coffee
@@ -134,7 +134,7 @@ class Repo extends Model
       callback: (name) ->
         git.cmd "checkout -b #{name}"
         .catch (error) -> new ErrorView(error)
-        .done -> atom.workspaceView.trigger 'atomatigit:refresh'
+        .done -> atom.workspaceView.trigger 'atomatigit:focus'
 
   # Public: Initiate a user defined git command.
   initiateGitCommand: =>
@@ -144,7 +144,7 @@ class Repo extends Model
         git.cmd command
         .then (output) -> new OutputView(output)
         .catch (error) -> new ErrorView(error)
-        .done -> atom.workspaceView.trigger 'atomatigit:refresh'
+        .done -> atom.workspaceView.trigger 'atomatigit:focus'
 
   # Public: Push the repository to the remote.
   push: =>

--- a/lib/views/branches/branch-brief-view.coffee
+++ b/lib/views/branches/branch-brief-view.coffee
@@ -1,29 +1,44 @@
 {View} = require 'atom'
 
+# Hash to store commit comparisons based on branch names
+branch_comparisons = {}
+
 # Public: Visual representation of a brief branch.
 class BranchBriefView extends View
   @content: ->
     @div class: 'branch-brief-view', mousedown: 'clicked', =>
       @div class: 'name', outlet: 'name'
       @div class: 'commit', outlet: 'commit'
+      @div class: 'comparison', outlet: 'comparison'
 
   # Public: Constructor.
   initialize: (@model) ->
     @model.on 'change:selected', @showSelection
+    @model.on 'comparison-loaded', @updateComparison if @model.local
     @repaint()
 
   # Public: 'beforeRemove' handler.
   beforeRemove: =>
     @model.off 'change:selected', @showSelection
+    @model.off 'comparison-loaded', @updateComparison if @model.local
 
   # Public: 'clicked' handler.
   clicked: =>
     @model.selfSelect()
 
+  # Internal: Update comparison string
+  updateComparison: =>
+    return unless atom.config.get('atomatigit.display_commit_comparisons')
+    name = @model.getName()
+    comparison = @model.comparison || branch_comparisons[name]
+    branch_comparisons[name] = comparison if comparison isnt ''
+    @comparison.html(comparison || 'Calculating...')
+
   # Public: Trigger a repaint.
   repaint: =>
     @name.html("#{@model.getName()}")
     @commit.html("(#{@model.commit().shortID()}: #{@model.commit().shortMessage()})")
+    @updateComparison() if @model.local
 
     @commit.removeClass 'unpushed'
     if @model.unpushed()

--- a/lib/views/branches/current-branch-view.coffee
+++ b/lib/views/branches/current-branch-view.coffee
@@ -1,25 +1,40 @@
 {View} = require 'atom'
 
+# Hash to store commit comparisons based on branch names
+branch_comparisons = {}
+
 # Public: Visual representation of the current branch.
 class CurrentBranchView extends View
   @content: ->
     @div class: 'current-branch-view', =>
       @div class: 'name', outlet: 'name'
       @div class: 'commit', outlet: 'commit'
+      @div class: 'comparison', outlet: 'comparison'
 
   # Public: Constructor.
   initialize: (@model) ->
     @model.on 'repaint', @repaint
+    @model.on 'comparison-loaded', @updateComparison
     @repaint()
 
   # Public: 'beforeRemove' handler.
   beforeRemove: =>
     @model.off 'repaint', @repaint
+    @model.off 'comparison-loaded', @updateComparison
+
+  # Internal: Update comparison string
+  updateComparison: =>
+    return @comparison.html('') unless atom.config.get('atomatigit.display_commit_comparisons')
+    name = @model.getName()
+    comparison = @model.comparison || branch_comparisons[name]
+    branch_comparisons[name] = comparison if comparison isnt ''
+    @comparison.html(comparison || 'Calculating...')
 
   # Public: Trigger a repaint.
   repaint: =>
     @name.html("#{@model.name}")
     @commit.html("(#{@model.commit.shortID?()}: #{@model.commit.shortMessage?()})")
+    @updateComparison()
 
     @commit.removeClass 'unpushed'
     @commit.addClass 'unpushed' if @model.unpushed()

--- a/lib/views/repo-view.coffee
+++ b/lib/views/repo-view.coffee
@@ -35,9 +35,6 @@ class RepoView extends View
       .on 'keyup', @unfocusIfNotActive
     @resizeHandle.on 'mousedown', @resizeStarted
 
-    atomGit = atom.project.getRepo()
-    @subscribe(atomGit, 'status-changed', @model.reload) if atomGit?
-
     @insertCommands()
     @InitPromise = @model.reload().then @showFiles
 
@@ -83,7 +80,6 @@ class RepoView extends View
   # Public: Force a full refresh.
   refresh: =>
     @model.reload().then => @activeView.repaint()
-    @focus()
 
   # Public: Show the 'branches' tab.
   showBranches: =>
@@ -149,9 +145,9 @@ class RepoView extends View
   unfocusIfNotActive: (e) =>
     return @unfocus() unless @hasFocus()
 
-  # Public: Focus the atomatigit pane.
+  # Public: Focus the atomatigit pane. Refresh if we're not refocusing.
   focus: =>
-    @activeView?.focus?() and @addClass 'focused'
+    @activeView?.focus?() and (@hasClass('focused') or @refresh()) and @addClass 'focused'
 
   # Public: Unfocus the atomatigit pane.
   unfocus: =>

--- a/lib/views/repo-view.coffee
+++ b/lib/views/repo-view.coffee
@@ -39,7 +39,7 @@ class RepoView extends View
     @subscribe(atomGit, 'status-changed', @model.reload) if atomGit?
 
     @insertCommands()
-    @model.reload().then @showFiles
+    @InitPromise = @model.reload().then @showFiles
 
   # Internal: Register atomatigit commands with atom.
   insertCommands: =>


### PR DESCRIPTION
+ 7f7f42c - When first opened, atomatigit would load twice. Using a Promise fixes that.
+ ee143d0 - If git commands were ever run outside of atomatigit, it wouldn't update. i.e. Doing `git checkout other_branch` in the command line would switch branches but atomatigit would still show that the old branch is selected.
+ 987a2ef - Meant to include this with the focus changes.
+ f1ad858 - Added the ability to see how much ahead / behind the tracking branch your local branches are. I put this behind a config flag so it's optional.
+ df3f749 - By making sure `atomatigit:close` always gets registered, opening a git repo will let the user close the pane.