### PR TITLE
Focus improvements

### DIFF
--- a/lib/models/branches/local-branch.coffee
+++ b/lib/models/branches/local-branch.coffee
@@ -87,7 +87,7 @@ class LocalBranch extends Branch
   push: (remote='origin') =>
     git.cmd 'push', [remote, @getName()]
     .then =>
-      @trigger 'update'
+      atom.workspaceView.trigger 'atomatigit:refresh'
       new OutputView('Pushing to remote repository successful')
     .catch (error) -> new ErrorView(error)
 

--- a/lib/views/repo-view.coffee
+++ b/lib/views/repo-view.coffee
@@ -35,6 +35,9 @@ class RepoView extends View
       .on 'keyup', @unfocusIfNotActive
     @resizeHandle.on 'mousedown', @resizeStarted
 
+    atomGit = atom.project.getRepo()
+    @subscribe(atomGit, 'status-changed', @model.reload) if atomGit?
+
     @insertCommands()
     @InitPromise = @model.reload().then @showFiles
 


### PR DESCRIPTION
+ dab0b25 - Subscribing doesn't update branch changes, but it does update file changes. I added it back in so if the view is open while editing files, it will still update.
+ d151f50 - After pushing a branch, we need to refresh the view so the commit comparisons will be on track.