### PR TITLE
Relabel Files tab to Staging

### DIFF
--- a/lib/views/repo-view.coffee
+++ b/lib/views/repo-view.coffee
@@ -15,7 +15,7 @@ class RepoView extends View
 
       @ul class: 'list-inline tab-bar inset-panel', =>
         @li outlet: 'fileTab', class: 'tab active', click: 'showFiles', =>
-          @div class: 'title', 'Files'
+          @div class: 'title', 'Staging'
         @li outlet: 'branchTab', class: 'tab', click: 'showBranches', =>
           @div class: 'title', 'Branches'
         @li outlet: 'commitTab', class: 'tab', click: 'showCommits', =>


### PR DESCRIPTION
Fixes #79 
I left references to the tab as "files" in the code and simply changed the tab label.  I thought this would be the least disruptive way to fix this.  I can go through and rename the references in the code if need be, but this small change introduces the minimum risk.